### PR TITLE
Finalize impl

### DIFF
--- a/lib/push_ex.ex
+++ b/lib/push_ex.ex
@@ -19,7 +19,7 @@ defmodule PushEx do
   defdelegate connected_channel_count(), to: Instrumentation.Tracker
 
   @doc """
-  Triggers a Push to be instrumented/enqueued into the system
+  Triggers a Push to be instrumented/enqueued into the system.
   """
   @spec push(%Push{}) :: true
   def push(item = %Push{}) do

--- a/lib/push_ex.ex
+++ b/lib/push_ex.ex
@@ -1,6 +1,6 @@
 defmodule PushEx do
   @moduledoc """
-  PushEx context exposes public API functions of PushEx, following the context model encouraged by Elixir.
+  PushEx context exposes public API functions
   """
 
   alias PushEx.{Instrumentation, Push}

--- a/lib/push_ex.ex
+++ b/lib/push_ex.ex
@@ -1,11 +1,22 @@
 defmodule PushEx do
   @moduledoc """
-  PushEx context exposes functions related to the core competency of PushEx, enqueueing pushes.
+  PushEx context exposes public API functions of PushEx, following the context model encouraged by Elixir.
   """
 
-  alias PushEx.Push
-  alias PushEx.Instrumentation
+  alias PushEx.{Instrumentation, Push}
   alias Push.ItemProducer
+
+  @doc """
+  Returns the number of sockets (transports) connected to this node.
+  """
+  @spec connected_socket_count() :: non_neg_integer()
+  defdelegate connected_socket_count(), to: Instrumentation.Tracker
+
+  @doc """
+  Returns the number of channels connected to this node.
+  """
+  @spec connected_channel_count() :: non_neg_integer()
+  defdelegate connected_channel_count(), to: Instrumentation.Tracker
 
   @doc """
   Triggers a Push to be instrumented/enqueued into the system

--- a/lib/push_ex.ex
+++ b/lib/push_ex.ex
@@ -1,6 +1,6 @@
 defmodule PushEx do
   @moduledoc """
-  PushEx context exposes public API functions
+  PushEx context exposes public API functions.
   """
 
   alias PushEx.{Instrumentation, Push}

--- a/lib/push_ex/behaviour/socket.ex
+++ b/lib/push_ex/behaviour/socket.ex
@@ -18,7 +18,7 @@ defmodule PushEx.Behaviour.Socket do
               | {:error, reason :: map()}
 
   @doc """
-  See `c:Phoenix.Socket.id/1`s
+  See `c:Phoenix.Socket.id/1`
   """
   @callback socket_id(Phoenix.Socket.t()) :: bitstring()
 

--- a/lib/push_ex/instrumentation/tracker.ex
+++ b/lib/push_ex/instrumentation/tracker.ex
@@ -1,8 +1,5 @@
 defmodule PushEx.Instrumentation.Tracker do
-  @moduledoc """
-  GenServer that tracks channels and transports to keep track of how many sockets/channels are connected currently.
-  All tracking is for the current node only. Presence must be used for full-cluster tracking.
-  """
+  @moduledoc false
 
   use GenServer
 
@@ -18,19 +15,11 @@ defmodule PushEx.Instrumentation.Tracker do
     {:ok, %{channel_pids: %{}, transport_pids: %{}}}
   end
 
-  @doc """
-  Returns the number of sockets (transports) connected to this node.
-  """
-  @spec connected_socket_count() :: non_neg_integer()
   def connected_socket_count(opts \\ []) do
     pid = Keyword.get(opts, :pid, __MODULE__)
     GenServer.call(pid, :connected_socket_count)
   end
 
-  @doc """
-  Returns the number of channels connected to this node.
-  """
-  @spec connected_channel_count() :: non_neg_integer()
   def connected_channel_count(opts \\ []) do
     pid = Keyword.get(opts, :pid, __MODULE__)
     GenServer.call(pid, :connected_channel_count)

--- a/test/push_ex_test.exs
+++ b/test/push_ex_test.exs
@@ -30,6 +30,18 @@ defmodule PushExTest do
     end
   end
 
+  describe "connected_channel_count/0" do
+    test "it is exposed" do
+      assert PushEx.connected_channel_count() == 0
+    end
+  end
+
+  describe "connected_socket_count/0" do
+    test "it is exposed" do
+      assert PushEx.connected_socket_count() == 0
+    end
+  end
+
   defp with_instrumentation(_) do
     PushEx.Test.MockInstrumenter.setup_config()
 


### PR DESCRIPTION
Hoist all public methods (other than behaviours) to the top level to give a stable API that doesn't reveal internals.