### PR TITLE
Recompile PushEx when the router loader’s AST changes

### DIFF
--- a/examples/test_frontend_socket/config/config.exs
+++ b/examples/test_frontend_socket/config/config.exs
@@ -26,6 +26,15 @@ config :push_ex, PushExWeb.PushSocket, socket_impl: TestFrontendSocket
 config :push_ex, PushExWeb.PushController, controller_impl: TestFrontendSocket
 
 additional_plug = quote do
+  pipeline :empty do
+  end
+
+  scope "/", TestFrontendSocket.Controller do
+    pipe_through :empty
+
+    get "/status7", Status, :show
+  end
+
   scope "/api", PushExWeb do
     pipe_through :api
 
@@ -34,4 +43,5 @@ additional_plug = quote do
 end
 
 config :push_ex, PushExWeb.Router,
-  additional_setup: additional_plug
+  additional_setup: additional_plug,
+  config_path: __ENV__.file

--- a/examples/test_frontend_socket/lib/test_frontend_socket/controller/status.ex
+++ b/examples/test_frontend_socket/lib/test_frontend_socket/controller/status.ex
@@ -1,0 +1,8 @@
+defmodule TestFrontendSocket.Controller.Status do
+  use PushExWeb, :controller
+
+  def show(conn, _params) do
+    conn
+    |> resp(200, "OK")
+  end
+end

--- a/guides/usage/custom_plugs.md
+++ b/guides/usage/custom_plugs.md
@@ -12,9 +12,12 @@ additional_setup = quote do
 end
 
 config :push_ex, PushExWeb.Router,
-  additional_setup: additional_setup
+  additional_setup: additional_setup,
+  config_path: __ENV__.file
 ```
 
 You can see that the additional setup uses a quoted block in order to include the custom code. This code will then be injected into the PushExWeb.Router at compile time.
 
-Due to this needing to happen at compile time, you must use a quoted block and not a module in your application's lib. Your app is compiled after all dependencies, but PushEx dependency would need access to a module in your app. This would cause an incorrect ordering and you would encounter a module not defined error. This also means that you would not be able to `use MyApp.CustomPlug` because `MyApp` isn't available during PushEx compilation.
+Due to this needing to happen at compile time, you must use a quoted block and not a module in your application's lib. Your app is compiled after all dependencies, but PushEx dependency would need access to a module in your app. This would cause an incorrect ordering and you would encounter a module not defined error. This also means that you would not be able to `use MyApp.CustomPlug` because `MyApp` isn't available during PushEx compilation. However, you are capable of writing controllers in your application similar to how `examples/test_frontend_socket` does with `Controller.Status`.
+
+You must path `config_path` for the additional plug setup to be compiled. This is due to needing to utilize `@external_resource` on your config file to cause PushEx to recompile on config.exs changes.

--- a/lib/push_ex_web/router.ex
+++ b/lib/push_ex_web/router.ex
@@ -7,7 +7,10 @@ defmodule PushExWeb.Router do
     plug :accepts, ["json"]
   end
 
-  use PushExWeb.RouterLoader
+  if PushExWeb.RouterLoader.external_resource() do
+    use PushExWeb.RouterLoader
+    @external_resource PushExWeb.RouterLoader.external_resource()
+  end
 
   scope "/api", PushExWeb do
     pipe_through :api

--- a/lib/push_ex_web/router_loader.ex
+++ b/lib/push_ex_web/router_loader.ex
@@ -12,4 +12,9 @@ defmodule PushExWeb.RouterLoader do
       ast
     end
   end
+
+  def external_resource() do
+    Application.get_env(:push_ex, PushExWeb.Router, [])
+    |> Keyword.get(:config_path)
+  end
 end


### PR DESCRIPTION
This fixes an issue with config.exs changes not causing recompilation of the router