### PR TITLE
Hibernate processes

### DIFF
--- a/examples/test_frontend_socket/mix.exs
+++ b/examples/test_frontend_socket/mix.exs
@@ -22,7 +22,8 @@ defmodule TestFrontendSocket.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:push_ex, ">= 0.0.0", path: "../.."}
+      {:push_ex, ">= 0.0.0", path: "../.."},
+      {:benchee, "~> 0.11", only: :dev}
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"},
     ]

--- a/examples/test_frontend_socket/mix.lock
+++ b/examples/test_frontend_socket/mix.lock
@@ -1,6 +1,8 @@
 %{
+  "benchee": {:hex, :benchee, "0.13.2", "30cd4ff5f593fdd218a9b26f3c24d580274f297d88ad43383afe525b1543b165", [:mix], [{:deep_merge, "~> 0.1", [hex: :deep_merge, repo: "hexpm", optional: false]}], "hexpm"},
   "cowboy": {:hex, :cowboy, "2.5.0", "4ef3ae066ee10fe01ea3272edc8f024347a0d3eb95f6fbb9aed556dacbfc1337", [:rebar3], [{:cowlib, "~> 2.6.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.6.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "2.6.0", "8aa629f81a0fc189f261dc98a42243fa842625feea3c7ec56c48f4ccdb55490f", [:rebar3], [], "hexpm"},
+  "deep_merge": {:hex, :deep_merge, "0.2.0", "c1050fa2edf4848b9f556fba1b75afc66608a4219659e3311d9c9427b5b680b3", [:mix], [], "hexpm"},
   "gen_stage": {:hex, :gen_stage, "0.14.1", "9d46723fda072d4f4bb31a102560013f7960f5d80ea44dcb96fd6304ed61e7a4", [:mix], [], "hexpm"},
   "gettext": {:hex, :gettext, "0.16.0", "4a7e90408cef5f1bf57c5a39e2db8c372a906031cc9b1466e963101cb927dafc", [:mix], [], "hexpm"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},

--- a/lib/push_ex/instrumentation/shard.ex
+++ b/lib/push_ex/instrumentation/shard.ex
@@ -21,6 +21,6 @@ defmodule PushEx.Instrumentation.Shard do
 
   def handle_cast({:exec, func}, state) do
     func.()
-    {:noreply, state}
+    {:noreply, state, :hibernate}
   end
 end

--- a/lib/push_ex_web/channels/push_channel.ex
+++ b/lib/push_ex_web/channels/push_channel.ex
@@ -35,7 +35,7 @@ defmodule PushExWeb.PushChannel do
   def handle_out("msg", item = %PushEx.Push{data: data, event: event}, socket) do
     push(socket, "msg", %{data: data, event: event})
     Instrumentation.Push.delivered(item)
-    {:noreply, socket}
+    {:noreply, socket, :hibernate}
   end
 
   def handle_info(:after_join, socket) do


### PR DESCRIPTION
This significantly saves memory in the system, and should be acceptable in most production setups because the number of processes getting pushes will be spread out across the process base.