### PR TITLE
Expose the transport connected pids

### DIFF
--- a/lib/push_ex.ex
+++ b/lib/push_ex.ex
@@ -19,6 +19,16 @@ defmodule PushEx do
   defdelegate connected_channel_count(), to: Instrumentation.Tracker
 
   @doc """
+  Returns the pids of connected transport processes (Socket processes).
+  """
+  defdelegate connected_transport_pids(), to: Instrumentation.Tracker
+
+  @doc """
+  Returns the pids of connected Channel processes.
+  """
+  defdelegate connected_channel_pids(), to: Instrumentation.Tracker
+
+  @doc """
   Returns a child_spec that can be used to start the PushEx web endpoint.
   """
   defdelegate child_spec(opts), to: PushEx.Supervisor

--- a/lib/push_ex/instrumentation/tracker.ex
+++ b/lib/push_ex/instrumentation/tracker.ex
@@ -25,6 +25,16 @@ defmodule PushEx.Instrumentation.Tracker do
     GenServer.call(pid, :connected_channel_count)
   end
 
+  def connected_transport_pids(opts \\ []) do
+    pid = Keyword.get(opts, :pid, __MODULE__)
+    GenServer.call(pid, :connected_transport_pids)
+  end
+
+  def connected_channel_pids(opts \\ []) do
+    pid = Keyword.get(opts, :pid, __MODULE__)
+    GenServer.call(pid, :connected_channel_pids)
+  end
+
   @doc false
   def track_channel(socket = %Phoenix.Socket{}, opts \\ []) do
     pid = Keyword.get(opts, :pid, __MODULE__)
@@ -51,6 +61,14 @@ defmodule PushEx.Instrumentation.Tracker do
 
   def handle_call(:connected_socket_count, _from, state = %{transport_pids: pids}) do
     {:reply, map_size(pids), state}
+  end
+
+  def handle_call(:connected_transport_pids, _from, state = %{transport_pids: pids}) do
+    {:reply, Map.keys(pids), state}
+  end
+
+  def handle_call(:connected_channel_pids, _from, state = %{channel_pids: pids}) do
+    {:reply, Map.keys(pids), state}
   end
 
   def handle_call(

--- a/test/push_ex/instrumentation/tracker_test.exs
+++ b/test/push_ex/instrumentation/tracker_test.exs
@@ -22,6 +22,8 @@ defmodule PushEx.Instrumentation.TrackerTest do
 
       assert Tracker.connected_channel_count(pid: pid) == 1
       assert Tracker.connected_socket_count(pid: pid) == 0
+      assert [cpid] = Tracker.connected_channel_pids(pid: pid)
+      assert is_pid(cpid)
 
       assert Tracker.track_channel(socket2, pid: pid) == :ok
 
@@ -89,6 +91,8 @@ defmodule PushEx.Instrumentation.TrackerTest do
 
       assert Tracker.connected_channel_count(pid: pid) == 0
       assert Tracker.connected_socket_count(pid: pid) == 1
+      assert [tpid] = Tracker.connected_transport_pids(pid: pid)
+      assert is_pid(tpid)
 
       assert Tracker.track_socket(socket2, pid: pid) == :ok
       empty_map = %{}
@@ -105,6 +109,7 @@ defmodule PushEx.Instrumentation.TrackerTest do
       assert Tracker.connected_socket_count(pid: pid) == 1
       Process.exit(transport_pid2, :kill) && Process.sleep(10)
       assert Tracker.connected_socket_count(pid: pid) == 0
+      assert Tracker.connected_transport_pids() == []
 
       assert Tracker.state(pid: pid) == %{
                channel_pids: %{},

--- a/test/push_ex_test.exs
+++ b/test/push_ex_test.exs
@@ -47,6 +47,18 @@ defmodule PushExTest do
     end
   end
 
+  describe "connected_transport_pids/0" do
+    test "it is exposed" do
+      assert PushEx.connected_transport_pids() == []
+    end
+  end
+
+  describe "connected_channel_pids/0" do
+    test "it is exposed" do
+      assert PushEx.connected_channel_pids() == []
+    end
+  end
+
   defp with_instrumentation(_) do
     PushEx.Test.MockInstrumenter.setup_config()
 


### PR DESCRIPTION
I will be using this to write an Elixir based cluster load balancer that kills sockets. I didn't
want to rely on a private API for it.
