### PR TITLE
Add ignored topics for handling public channels

### DIFF
--- a/examples/test_frontend_socket/assets/app.js
+++ b/examples/test_frontend_socket/assets/app.js
@@ -43,12 +43,17 @@
 
   joinChannel("test")
   joinChannel("test2")
+  joinChannel("my-public-channel")
 
   pushex.subscribe('test').bind('*', (event, data) => {
     stageNotification(`test: ${event}-${data}`)
     console.log('test channel received event/data', event, data)
   })
   pushex.subscribe('test2').bind('*', (event, data) => {
+    stageNotification(`test2: ${event}: ${data}`)
+    console.log('test2 channel received event/data', event, data)
+  })
+  pushex.subscribe('my-public-channel').bind('*', (event, data) => {
     stageNotification(`test2: ${event}: ${data}`)
     console.log('test2 channel received event/data', event, data)
   })

--- a/examples/test_frontend_socket/assets/index.html
+++ b/examples/test_frontend_socket/assets/index.html
@@ -17,7 +17,7 @@
         http://localhost:4004/api/push \
         -H 'content-type: application/json' \
         -d '{
-        "channel": ["test", "test2", "test", "not connected"],
+        "channel": ["test", "test2", "test", "my-public-channel", "not connected"],
         "data": "data",
         "event": "woohoo"
       }'

--- a/examples/test_frontend_socket/config/config.exs
+++ b/examples/test_frontend_socket/config/config.exs
@@ -25,6 +25,9 @@ config :push_ex, PushExWeb.PushSocket, socket_impl: TestFrontendSocket
 
 config :push_ex, PushExWeb.PushController, controller_impl: TestFrontendSocket
 
+config :push_ex, PushExWeb.PushTracker,
+  untracked_topics: ["my-public-channel", "other-public-channel"]
+
 additional_plug = quote do
   pipeline :empty do
   end

--- a/guides/usage/public_topics.md
+++ b/guides/usage/public_topics.md
@@ -1,0 +1,18 @@
+# Public Topics
+
+A single topic which every client connects to is typically very expensive to track in a cluster. This
+is because the sharding algorithm works based on the `topic` value and the same topic will always be
+sharded the same way. This can cause a single shard to become "hot" and receive a bulk of work.
+
+If there is a public topic, it most likely is always going to have a connection to it. We therefore can
+treat it as always having a connection and not check if there is actively a connection. PushEx allows
+you to configure this using the `untracked_topics` configuration of `PushExWeb.PushTracker`.
+
+You can set it up like this:
+
+```elixir
+config :push_ex, PushExWeb.PushTracker,
+  untracked_topics: ["my-public-channel", "other-public-channel"]
+```
+
+The topic will appear in the `Pushex.Instrumentation.Tracker` but not in `PushExWeb.PushTracker`.

--- a/lib/push_ex/config.ex
+++ b/lib/push_ex/config.ex
@@ -51,6 +51,16 @@ defmodule PushEx.Config do
     |> Keyword.get(:push_listeners, [])
   end
 
+  @doc """
+  The list of topics which should be treated as always online and not tracked. This is useful for the situation
+  where there is a public topic that most likely always has a listener. It is very expensive to track these topics.
+  These topics will be tracked in `Instrumentation.Tracker` but not `Phoenix.Tracker` for performance reasons.
+  """
+  def untracked_push_tracker_topics() do
+    Application.get_env(:push_ex, PushExWeb.PushTracker, [])
+    |> Keyword.get(:untracked_topics, [])
+  end
+
   def check!() do
     check_socket_impl!()
     check_controller_impl!()

--- a/lib/push_ex_web/channels/push_tracker.ex
+++ b/lib/push_ex_web/channels/push_tracker.ex
@@ -29,15 +29,23 @@ defmodule PushExWeb.PushTracker do
   end
 
   def track(%Phoenix.Socket{topic: topic} = socket) do
-    id = PushEx.Config.socket_impl().presence_identifier(socket)
+    if topic in PushEx.Config.untracked_push_tracker_topics() do
+      {:ok, :ignored_topic}
+    else
+      id = PushEx.Config.socket_impl().presence_identifier(socket)
 
-    Phoenix.Tracker.track(__MODULE__, socket.channel_pid, topic, id, %{
-      online_at: PushEx.unix_ms_now()
-    })
+      Phoenix.Tracker.track(__MODULE__, socket.channel_pid, topic, id, %{
+        online_at: PushEx.unix_ms_now()
+      })
+    end
   end
 
   def listeners?(topic) do
-    Phoenix.Tracker.list(__MODULE__, topic)
-    |> Enum.any?()
+    if topic in PushEx.Config.untracked_push_tracker_topics() do
+      true
+    else
+      Phoenix.Tracker.list(__MODULE__, topic)
+      |> Enum.any?()
+    end
   end
 end

--- a/test/push_ex/config_test.exs
+++ b/test/push_ex/config_test.exs
@@ -90,4 +90,16 @@ defmodule PushEx.ConfigTest do
       Config.check!()
     end
   end
+
+  describe "untracked_push_tracker_topics/0" do
+    test "defaults to an empty list" do
+      Application.delete_env(:push_ex, PushExWeb.PushTracker)
+      assert Config.untracked_push_tracker_topics() == []
+    end
+
+    test "a value can be provided" do
+      Application.put_env(:push_ex, PushExWeb.PushTracker, untracked_topics: ["test", "test2"])
+      assert Config.untracked_push_tracker_topics() == ["test", "test2"]
+    end
+  end
 end


### PR DESCRIPTION
Public channels can be very expensive to track in a large system due to the way that a single topic
is sharded to the same value all the time. This causes a tracker node to run hot.

Probabilistically the topic will always have a listener and so we don't need to track it. We just always
broadcast a message.

# TODO

- [ ] Write tests for this before 1.0.0
