### PR TITLE
Graceful kills

### DIFF
--- a/examples/test_frontend_socket/mix.lock
+++ b/examples/test_frontend_socket/mix.lock
@@ -13,4 +13,5 @@
   "plug_cowboy": {:hex, :plug_cowboy, "2.0.0", "ab0c92728f2ba43c544cce85f0f220d8d30fc0c90eaa1e6203683ab039655062", [:mix], [{:cowboy, "~> 2.5", [hex: :cowboy, repo: "hexpm", optional: false]}, {:plug, "~> 1.7", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "plug_crypto": {:hex, :plug_crypto, "1.0.0", "18e49317d3fa343f24620ed22795ec29d4a5e602d52d1513ccea0b07d8ea7d4d", [:mix], [], "hexpm"},
   "ranch": {:hex, :ranch, "1.6.2", "6db93c78f411ee033dbb18ba8234c5574883acb9a75af0fb90a9b82ea46afa00", [:rebar3], [], "hexpm"},
+  "ranch_connection_drainer": {:hex, :ranch_connection_drainer, "0.1.2", "0de193cbe5213b86e590ab552643777c9bb75b55ece2a3e11d2fc384c6e9f4a5", [:mix], [{:ranch, "~> 1.6", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
 }

--- a/lib/push_ex/push/drainer.ex
+++ b/lib/push_ex/push/drainer.ex
@@ -1,0 +1,50 @@
+# Heavily influenced by RanchConnectionDrainer and :ranch
+defmodule PushEx.Push.Drainer do
+  @moduledoc false
+
+  use GenServer
+  require Logger
+
+  def child_spec(options) when is_list(options) do
+    producer_ref = Keyword.fetch!(options, :producer_ref)
+    shutdown = Keyword.fetch!(options, :shutdown)
+
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [producer_ref]},
+      shutdown: shutdown
+    }
+  end
+
+  def start_link(producer_ref) do
+    GenServer.start_link(__MODULE__, producer_ref)
+  end
+
+  def init(producer_ref) do
+    Process.flag(:trap_exit, true)
+    {:ok, producer_ref}
+  end
+
+  def terminate(_reason, producer_ref) do
+    Logger.info("Waiting for producer to drain for PushEx.Producer #{inspect(producer_ref)}...")
+    :ok = wait_for_drain_loop(producer_ref)
+    Logger.info("Producer successfully drained for PushEx.Producer #{inspect(producer_ref)}")
+  end
+
+  defp wait_for_drain_loop(producer_ref) do
+    count =
+      try do
+        PushEx.Push.ItemProducer.in_buffer_count(producer_ref)
+      catch
+        _, _ ->
+          0
+      end
+
+    if count == 0 do
+      :ok
+    else
+      Process.sleep(1000)
+      wait_for_drain_loop(producer_ref)
+    end
+  end
+end

--- a/lib/push_ex/supervisor.ex
+++ b/lib/push_ex/supervisor.ex
@@ -8,7 +8,8 @@ defmodule PushEx.Supervisor do
   def init(_) do
     children = [
       PushExWeb.Endpoint,
-      {PushExWeb.PushTracker, [pool_size: PushEx.Application.pool_size()]}
+      {PushExWeb.PushTracker, [pool_size: PushEx.Application.pool_size()]},
+      {RanchConnectionDrainer, ranch_ref: PushExWeb.Endpoint.HTTP, shutdown: 15_000}
     ]
 
     opts = [strategy: :one_for_one, name: __MODULE__]

--- a/lib/push_ex/supervisor.ex
+++ b/lib/push_ex/supervisor.ex
@@ -9,6 +9,7 @@ defmodule PushEx.Supervisor do
     children = [
       PushExWeb.Endpoint,
       {PushExWeb.PushTracker, [pool_size: PushEx.Application.pool_size()]},
+      {PushEx.Push.Drainer, producer_ref: PushEx.Push.ItemProducer, shutdown: 15_000},
       {RanchConnectionDrainer, ranch_ref: PushExWeb.Endpoint.HTTP, shutdown: 15_000}
     ]
 

--- a/mix.exs
+++ b/mix.exs
@@ -57,6 +57,7 @@ defmodule PushEx.MixProject do
       {:plug_cowboy, "~> 2.0"},
       {:plug, "~> 1.7"},
       {:gen_stage, "~> 0.14"},
+      {:ranch_connection_drainer, "~> 0.1.0"},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -16,4 +16,5 @@
   "plug_cowboy": {:hex, :plug_cowboy, "2.0.0", "ab0c92728f2ba43c544cce85f0f220d8d30fc0c90eaa1e6203683ab039655062", [:mix], [{:cowboy, "~> 2.5", [hex: :cowboy, repo: "hexpm", optional: false]}, {:plug, "~> 1.7", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "plug_crypto": {:hex, :plug_crypto, "1.0.0", "18e49317d3fa343f24620ed22795ec29d4a5e602d52d1513ccea0b07d8ea7d4d", [:mix], [], "hexpm"},
   "ranch": {:hex, :ranch, "1.6.2", "6db93c78f411ee033dbb18ba8234c5574883acb9a75af0fb90a9b82ea46afa00", [:rebar3], [], "hexpm"},
+  "ranch_connection_drainer": {:hex, :ranch_connection_drainer, "0.1.2", "0de193cbe5213b86e590ab552643777c9bb75b55ece2a3e11d2fc384c6e9f4a5", [:mix], [{:ranch, "~> 1.6", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
 }

--- a/test/push_ex/push/drainer_test.exs
+++ b/test/push_ex/push/drainer_test.exs
@@ -1,0 +1,143 @@
+defmodule PushEx.Push.DrainerTest do
+  use ExUnit.Case, async: true
+
+  alias PushEx.Push.Drainer
+
+  defmodule MockProducer do
+    use GenServer
+
+    def start_link(count) do
+      GenServer.start_link(__MODULE__, count)
+    end
+
+    def init(count) do
+      {:ok, %GenStage{buffer: {nil, count, nil}}}
+    end
+
+    def set_count(pid, count) do
+      GenServer.call(pid, {:set_count, count})
+    end
+
+    def kill(pid) do
+      try do
+        GenServer.call(pid, :kill)
+      catch
+        _, _ -> nil
+      end
+    end
+
+    def handle_call({:set_count, count}, _, _) do
+      {:reply, :ok, %GenStage{buffer: {nil, count, nil}}}
+    end
+
+    def handle_call(:kill, _, state) do
+      {:stop, :normal, state}
+    end
+  end
+
+  test "the process terminates if there are no jobs in the ItemProducer" do
+    {:ok, producer_pid} = PushEx.Push.ItemProducer.start_link(:nameless)
+
+    {:ok, drain_pid} =
+      Supervisor.start_link(
+        [
+          {Drainer, producer_ref: producer_pid, shutdown: 1000}
+        ],
+        strategy: :one_for_one
+      )
+
+    Process.exit(drain_pid, :normal) && Process.sleep(20)
+    refute Process.alive?(drain_pid)
+  end
+
+  test "the ItemProducer can be already dead and it will exit successfully" do
+    {:ok, producer_pid} = PushEx.Push.ItemProducer.start_link(:nameless)
+
+    {:ok, drain_pid} =
+      Supervisor.start_link(
+        [
+          {Drainer, producer_ref: producer_pid, shutdown: 1000}
+        ],
+        strategy: :one_for_one
+      )
+
+    assert :ok = GenStage.stop(producer_pid)
+    refute Process.alive?(producer_pid)
+
+    Process.exit(drain_pid, :normal) && Process.sleep(25)
+    refute Process.alive?(drain_pid)
+  end
+
+  test "the drainer will hang for shutdown ms if there is an item in the buffer" do
+    {:ok, producer_pid} = PushEx.Push.ItemProducer.start_link(:nameless)
+
+    {:ok, drain_pid} =
+      Supervisor.start_link(
+        [
+          {Drainer, producer_ref: producer_pid, shutdown: 3000}
+        ],
+        strategy: :one_for_one
+      )
+
+    PushEx.Push.ItemProducer.push(%PushEx.Push{channel: nil, data: nil, event: nil, unix_ms: nil}, producer_pid)
+    Process.exit(drain_pid, :normal)
+
+    Process.sleep(1000)
+    assert Process.alive?(drain_pid)
+
+    Process.sleep(1000)
+    assert Process.alive?(drain_pid)
+
+    Process.sleep(600)
+    assert Process.alive?(drain_pid)
+
+    Process.sleep(600)
+    refute Process.alive?(drain_pid)
+  end
+
+  test "the drainer will complete before the shutdown ms if the item in buffer is removed" do
+    {:ok, producer_pid} = MockProducer.start_link(1)
+
+    {:ok, drain_pid} =
+      Supervisor.start_link(
+        [
+          {Drainer, producer_ref: producer_pid, shutdown: 3000}
+        ],
+        strategy: :one_for_one
+      )
+
+    Process.exit(drain_pid, :normal)
+
+    Process.sleep(1000)
+    assert Process.alive?(drain_pid)
+
+    MockProducer.set_count(producer_pid, 0)
+
+    # Give it slightly more than 1000 as it re-runs that often
+    Process.sleep(1100)
+    refute Process.alive?(drain_pid)
+  end
+
+  test "the drainer will complete before the shutdown ms if the producer pid dies" do
+    {:ok, producer_pid} = MockProducer.start_link(1)
+
+    {:ok, drain_pid} =
+      Supervisor.start_link(
+        [
+          {Drainer, producer_ref: producer_pid, shutdown: 3000}
+        ],
+        strategy: :one_for_one
+      )
+
+    Process.exit(drain_pid, :normal)
+    Process.sleep(1000)
+    assert Process.alive?(drain_pid)
+
+    MockProducer.kill(producer_pid)
+    refute Process.alive?(producer_pid)
+
+    # Give it slightly more than 1000 as it re-runs that often
+    Process.sleep(1100)
+    refute Process.alive?(drain_pid)
+  end
+end


### PR DESCRIPTION
Allows PushEx server to gracefully exit by ensuring that ranch stops accepting connections and processes exiting ones, plus ensures that the message queue is empty.

We don't kill the node from distribution (preventing incoming messages) because we want to ensure that messages are delivered as late as possible (minimizing missed messages). The message flow utilizes Tracker which should be killed *after* it. This means that PushEx will have no connected channels by the time Tracker is killed.