### PR TITLE
Disconnect sockets on exit

### DIFF
--- a/examples/test_frontend_socket/assets/package-lock.json
+++ b/examples/test_frontend_socket/assets/package-lock.json
@@ -9,11 +9,18 @@
       "integrity": "sha512-+M7erjPRtrHM53Bc9sT/WSyNFOEhsAc48PBsex0R87hu0GhBRMNE2uAb8MT2gKtJmAYxv5Quaozh/PBuhO8tdQ=="
     },
     "pushex": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/pushex/-/pushex-0.0.7.tgz",
-      "integrity": "sha512-3T+mzZO6IrpU7CbTOVZDIEuWo0z8PR+38no7cQKoupJ3f/l/aVAezmZ1HhreSmT286RpwQvrT9GLa2lgV8w5+Q==",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/pushex/-/pushex-0.0.10.tgz",
+      "integrity": "sha512-/nrWabDDDfQ3+eApsEq7v/4wi9wGYfjFsgbQx/uVO7EvvodXuOgjkEyL9vfnTfDLRDVAv6RanYTE7FMsP0wInA==",
       "requires": {
-        "phoenix": "^1.4.0"
+        "phoenix": "^1.4.3"
+      },
+      "dependencies": {
+        "phoenix": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/phoenix/-/phoenix-1.4.3.tgz",
+          "integrity": "sha512-FU7Ms8SOAGqECRC0RLQMZnLTdrXWureefM0t9K6AqK9jo4hpvUTqjskN/RaGOBXcFGIvgM2F5AFcMop4PPwOSA=="
+        }
       }
     }
   }

--- a/examples/test_frontend_socket/assets/package.json
+++ b/examples/test_frontend_socket/assets/package.json
@@ -2,6 +2,6 @@
   "name": "test_frontend",
   "dependencies": {
     "phoenix": "^1.4.0",
-    "pushex": "~> 0.0.7"
+    "pushex": "~> 0.0.10"
   }
 }

--- a/examples/test_frontend_socket/config/config.exs
+++ b/examples/test_frontend_socket/config/config.exs
@@ -21,7 +21,9 @@ config :phoenix, :json_library, Jason
 
 config :push_ex, PushEx.Instrumentation, push_listeners: [TestFrontendSocket.PushInstrumenter]
 
-config :push_ex, PushExWeb.PushSocket, socket_impl: TestFrontendSocket
+config :push_ex, PushExWeb.PushSocket,
+  socket_impl: TestFrontendSocket,
+  disconnect_sockets_on_shutdown: true
 
 config :push_ex, PushExWeb.PushController, controller_impl: TestFrontendSocket
 

--- a/guides/usage/deployment.md
+++ b/guides/usage/deployment.md
@@ -33,6 +33,19 @@ restarting for deployments. PushEx tries to handle a lot of this for you by prov
 server and for the Push.ItemProducer data pipeline. Each item is given 10 seconds to complete (20s) total. This
 should minimize the likelihood of a process being offline but connections still trying to use the process.
 
+Sockets can be disconnected when the server is brought offline. This is *not* performed by default as it
+could be the wrong thing to do in certain environments. It is easy to turn on this option with a configuration:
+
+```elixir
+config :push_ex, PushExWeb.PushSocket,
+  socket_impl: TestFrontendSocket,
+  disconnect_sockets_on_shutdown: true
+```
+
+Local socket transports will be sent a disconnect broadcast. The client will automatically start reconnecting
+to establish the connection. It is important that your load balancer does not send any new connections to the
+old node or it will not be able to shutdown cleanly.
+
 ## Recommendations
 
 Every company will be different with regards to how they deploy application: docker, amazon, google, heroku, kubernetes, the list goes on. Therefore, it's impossible to make a direct recommendation of what you should do when deploying PushEx. However, I can caution that Heroku will most likely be a bad choice for large applications and instead you should consider other routes.

--- a/lib/push_ex/config.ex
+++ b/lib/push_ex/config.ex
@@ -61,6 +61,14 @@ defmodule PushEx.Config do
     |> Keyword.get(:untracked_topics, [])
   end
 
+  @doc """
+  Whether sockets will be automatically disconnected on shutdown, defaults to false for safety reasons
+  """
+  def disconnect_sockets_on_shutdown() do
+    Application.get_env(:push_ex, PushExWeb.PushSocket, [])
+    |> Keyword.get(:disconnect_sockets_on_shutdown, false)
+  end
+
   def check!() do
     check_socket_impl!()
     check_controller_impl!()

--- a/lib/push_ex/supervisor.ex
+++ b/lib/push_ex/supervisor.ex
@@ -13,7 +13,7 @@ defmodule PushEx.Supervisor do
         PushExWeb.Endpoint,
         {PushExWeb.PushTracker, [pool_size: PushEx.Application.pool_size()]},
         {PushEx.Push.Drainer, producer_ref: PushEx.Push.ItemProducer, shutdown: @shutdown_timeout}
-      ] ++ ranch_connection_drainers()
+      ] ++ ranch_connection_drainers() ++ socket_drainer()
 
     opts = [strategy: :one_for_one, name: __MODULE__]
     Supervisor.init(children, opts)
@@ -21,6 +21,16 @@ defmodule PushEx.Supervisor do
 
   defp ranch_connection_drainers() do
     ranch_connection_drainer_http() ++ ranch_connection_drainer_https()
+  end
+
+  defp socket_drainer() do
+    if PushEx.Config.disconnect_sockets_on_shutdown() do
+      [
+        {PushExWeb.SocketDrainer, shutdown: @shutdown_timeout}
+      ]
+    else
+      []
+    end
   end
 
   defp ranch_connection_drainer_http() do

--- a/lib/push_ex_web/channels/socket_drainer.ex
+++ b/lib/push_ex_web/channels/socket_drainer.ex
@@ -1,0 +1,67 @@
+defmodule PushExWeb.SocketDrainer do
+  @moduledoc false
+
+  use GenServer
+  require Logger
+
+  def child_spec(options) when is_list(options) do
+    tracker_ref = Keyword.get(options, :tracker_ref, PushEx.Instrumentation.Tracker)
+    shutdown = Keyword.fetch!(options, :shutdown)
+
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [tracker_ref]},
+      shutdown: shutdown
+    }
+  end
+
+  def start_link(tracker_ref) do
+    GenServer.start_link(__MODULE__, [tracker_ref])
+  end
+
+  def init([tracker_ref]) do
+    Process.flag(:trap_exit, true)
+    {:ok, tracker_ref}
+  end
+
+  def terminate(_reason, tracker_ref) do
+    Logger.info("Waiting for sockets to drain for PushExWeb.PushSocket #{inspect(tracker_ref)}...")
+    :ok = wait_for_drain_loop(tracker_ref)
+    Logger.info("Sockets successfully drained for PushExWeb.PushSocket #{inspect(tracker_ref)}")
+  end
+
+  defp wait_for_drain_loop(tracker_ref) do
+    if connected_socket_count(tracker_ref) == 0 do
+      :ok
+    else
+      kill_all_socket_connections(tracker_ref)
+      Process.sleep(100)
+      wait_for_drain_loop(tracker_ref)
+    end
+  end
+
+  defp connected_socket_count(tracker_ref) do
+    try do
+      PushEx.Instrumentation.Tracker.connected_socket_count(pid: tracker_ref)
+    catch
+      _, _ ->
+        0
+    end
+  end
+
+  defp connected_socket_pids(tracker_ref) do
+    try do
+      PushEx.Instrumentation.Tracker.connected_transport_pids(pid: tracker_ref)
+    catch
+      _, _ ->
+        []
+    end
+  end
+
+  defp kill_all_socket_connections(tracker_ref) do
+    connected_socket_pids(tracker_ref)
+    |> Enum.each(fn pid ->
+      send(pid, %Phoenix.Socket.Broadcast{event: "disconnect"})
+    end)
+  end
+end

--- a/test/push_ex_web/channels/socket_drainer_test.exs
+++ b/test/push_ex_web/channels/socket_drainer_test.exs
@@ -1,6 +1,5 @@
 defmodule PushExWeb.SocketDrainerTest do
-  # Can not be async because global process names are used
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   alias PushExWeb.SocketDrainer
   alias PushEx.Instrumentation.Tracker

--- a/test/push_ex_web/channels/socket_drainer_test.exs
+++ b/test/push_ex_web/channels/socket_drainer_test.exs
@@ -1,0 +1,85 @@
+defmodule PushExWeb.SocketDrainerTest do
+  # Can not be async because global process names are used
+  use ExUnit.Case, async: false
+
+  alias PushExWeb.SocketDrainer
+  alias PushEx.Instrumentation.Tracker
+
+  setup :with_tracker
+
+  test "no connected sockets completes right away", %{pid: pid} do
+    {:ok, drain_pid} =
+      Supervisor.start_link(
+        [
+          {SocketDrainer, tracker_ref: pid, shutdown: 1000}
+        ],
+        strategy: :one_for_one
+      )
+
+    Process.exit(drain_pid, :normal) && Process.sleep(50)
+    refute Process.alive?(drain_pid)
+  end
+
+  test "1 connected socket doesn't complete", %{pid: pid} do
+    {:ok, drain_pid} =
+      Supervisor.start_link(
+        [
+          {SocketDrainer, tracker_ref: pid, shutdown: 1000}
+        ],
+        strategy: :one_for_one
+      )
+
+    transport_pid = spawn(fn -> Process.sleep(10000) end)
+    socket = %Phoenix.Socket{transport: :ws, transport_pid: transport_pid}
+    PushEx.Test.MockSocket.setup_config()
+
+    assert Tracker.track_socket(socket, pid: pid) == :ok
+    Process.sleep(20)
+    assert PushEx.Instrumentation.Tracker.connected_socket_count(pid: pid) == 1
+
+    Process.exit(drain_pid, :normal) && Process.sleep(20)
+    assert Process.alive?(drain_pid)
+
+    Process.sleep(500)
+    assert Process.alive?(drain_pid)
+
+    Process.sleep(500)
+    refute Process.alive?(drain_pid)
+  end
+
+  test "1 connected socket which ends does", %{pid: pid} do
+    {:ok, drain_pid} =
+      Supervisor.start_link(
+        [
+          {SocketDrainer, tracker_ref: pid, shutdown: 1000}
+        ],
+        strategy: :one_for_one
+      )
+
+    transport_pid = spawn(fn -> Process.sleep(10000) end)
+    socket = %Phoenix.Socket{transport: :ws, transport_pid: transport_pid}
+    PushEx.Test.MockSocket.setup_config()
+
+    assert Tracker.track_socket(socket, pid: pid) == :ok
+    Process.sleep(20)
+    assert PushEx.Instrumentation.Tracker.connected_socket_count(pid: pid) == 1
+
+    Process.exit(drain_pid, :normal) && Process.sleep(20)
+    assert Process.alive?(drain_pid)
+    Process.exit(transport_pid, :shutdown)
+
+    Process.sleep(500)
+    refute Process.alive?(drain_pid)
+  end
+
+  defp with_tracker(_) do
+    # Intentionally not linked, as this process will be killed in tests
+    {:ok, pid} = GenServer.start(Tracker, [])
+
+    on_exit(fn ->
+      Process.exit(pid, :kill)
+    end)
+
+    {:ok, %{pid: pid}}
+  end
+end


### PR DESCRIPTION
Create a socket drainer that disconnects websockets on exit
    
This is an aggressive action but can be very useful for ensuring that the system cleanly shuts down. The caveats are discussed in the deployment file.

Add the config `disconnect_sockets_on_shutdown: true` to the PushExWeb.PushSocket config in order to use this.