### PR TITLE
Timing out in the PushTracker should behave as if there are listeners

### DIFF
--- a/test/push_ex_web/channels/push_presence_test.exs
+++ b/test/push_ex_web/channels/push_presence_test.exs
@@ -1,1 +1,0 @@
-# Tested in push_channel_test.exs

--- a/test/push_ex_web/channels/push_tracker_test.exs
+++ b/test/push_ex_web/channels/push_tracker_test.exs
@@ -1,0 +1,76 @@
+defmodule PushExWeb.PushTrackerTest do
+  use ExUnit.Case, async: false
+  alias PushExWeb.PushTracker
+
+  setup do
+    Application.put_env(:push_ex, PushExWeb.PushTracker, untracked_topics: [])
+
+    :ok
+  end
+
+  describe "track/1" do
+    test "the channel is tracked using the topic and configured presence id" do
+      PushEx.Test.MockSocket.setup_config()
+
+      topic = make_ref()
+      assert {:ok, ref} = PushTracker.track(%Phoenix.Socket{
+        topic: topic,
+        channel_pid: self(),
+        id: make_ref()
+      })
+
+      assert [{"id", %{online_at: _, phx_ref: ^ref}}] = Phoenix.Tracker.list(PushTracker, topic)
+    end
+
+    test "a topic can be ignored and will not become tracked" do
+      PushEx.Test.MockSocket.setup_config()
+
+      topic = make_ref()
+      Application.put_env(:push_ex, PushExWeb.PushTracker, untracked_topics: ["x", topic])
+
+      assert {:ok, :ignored_topic} = PushTracker.track(%Phoenix.Socket{
+        topic: topic,
+        channel_pid: self(),
+        id: make_ref()
+      })
+
+      assert Phoenix.Tracker.list(PushTracker, topic) == []
+    end
+  end
+
+  describe "listeners?/1" do
+    test "false without a tracked channel" do
+      refute PushTracker.listeners?(make_ref())
+    end
+
+    test "true if there is a tracked channel" do
+      PushEx.Test.MockSocket.setup_config()
+
+      topic = make_ref()
+      pid = spawn(fn -> Process.sleep(10_000) end)
+      assert {:ok, ref} = PushTracker.track(%Phoenix.Socket{
+        topic: topic,
+        channel_pid: pid,
+        id: make_ref()
+      })
+
+      assert PushTracker.listeners?(topic)
+
+      Process.exit(pid, :shutdown) && Process.sleep(10)
+
+      refute PushTracker.listeners?(topic)
+    end
+
+    test "true if the channel is untracked" do
+      topic = make_ref()
+      Application.put_env(:push_ex, PushExWeb.PushTracker, untracked_topics: ["x", topic])
+      assert PushTracker.listeners?(topic)
+    end
+
+    test "true if the tracker call experiences a timeout to ensure that messages aren't missed" do
+      topic = make_ref()
+      refute PushTracker.listeners?(topic, 5)
+      assert PushTracker.listeners?(topic, 0)
+    end
+  end
+end


### PR DESCRIPTION
There is no need to miss a message because the Tracker is overloaded. Instead let's treat timeouts as `true`
and send the message even if there isn't a listener.

## Description

Timeouts in the PushExWeb.Tracker module for listeners? request will be treated as true.

## Motivation and Context

Timeouts due to an overloaded server shouldn't cause missed messages.

## How Has This Been Tested?

Unit tests

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
